### PR TITLE
feat: Add option to modify how a query is printed

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ class StorageProvider(StorageProviderBase):
     def postprocess_query(self, query: str) -> str:
         return query
 
+    # This can be used to change how the rendered query is displayed in the logs to
+    # prevent accidentally printing sensitive information e.g. tokens in a URL.
+    def safe_print(self, query: str) -> str:
+        """Process the query to remove potentially sensitive information when printing.
+        """
+        return query
+
 
 # Required:
 # Implementation of storage object. If certain methods cannot be supported by your

--- a/snakemake_interface_storage_plugins/storage_object.py
+++ b/snakemake_interface_storage_plugins/storage_object.py
@@ -144,21 +144,23 @@ class StorageObjectRead(StorageObjectBase):
             async with self._rate_limiter(Operation.SIZE):
                 return self.size()
         except Exception as e:
-            raise WorkflowError(f"Failed to get size of {self.print_query}", e)
+            raise WorkflowError(f"Failed to get size of {self.print_query}") from e
 
     async def managed_mtime(self) -> float:
         try:
             async with self._rate_limiter(Operation.MTIME):
                 return self.mtime()
         except Exception as e:
-            raise WorkflowError(f"Failed to get mtime of {self.print_query}", e)
+            raise WorkflowError(f"Failed to get mtime of {self.print_query}") from e
 
     async def managed_exists(self) -> bool:
         try:
             async with self._rate_limiter(Operation.EXISTS):
                 return self.exists()
         except Exception as e:
-            raise WorkflowError(f"Failed to check existence of {self.print_query}", e)
+            raise WorkflowError(
+                f"Failed to check existence of {self.print_query}"
+            ) from e
 
     async def managed_retrieve(self):
         try:
@@ -174,8 +176,8 @@ class StorageObjectRead(StorageObjectBase):
                 else:
                     os.remove(local_path)
             raise WorkflowError(
-                f"Failed to retrieve storage object from {self.print_query}", e
-            )
+                f"Failed to retrieve storage object from {self.print_query}"
+            ) from e
 
 
 class StorageObjectWrite(StorageObjectBase):
@@ -224,4 +226,6 @@ class StorageObjectTouch(StorageObjectBase):
             async with self._rate_limiter(Operation.TOUCH):
                 self.touch()
         except Exception as e:
-            raise WorkflowError(f"Failed to touch storage object {self.print_query}", e)
+            raise WorkflowError(
+                f"Failed to touch storage object {self.print_query}"
+            ) from e

--- a/snakemake_interface_storage_plugins/storage_object.py
+++ b/snakemake_interface_storage_plugins/storage_object.py
@@ -68,6 +68,7 @@ class StorageObjectBase(ABC):
         self.keep_local = keep_local
         self.retrieve = retrieve
         self.provider = provider
+        self.print_query = self.provider.safe_print(self.query)
         self._overwrite_local_path = None
         self.__post_init__()
 
@@ -143,21 +144,21 @@ class StorageObjectRead(StorageObjectBase):
             async with self._rate_limiter(Operation.SIZE):
                 return self.size()
         except Exception as e:
-            raise WorkflowError(f"Failed to get size of {self.query}", e)
+            raise WorkflowError(f"Failed to get size of {self.print_query}", e)
 
     async def managed_mtime(self) -> float:
         try:
             async with self._rate_limiter(Operation.MTIME):
                 return self.mtime()
         except Exception as e:
-            raise WorkflowError(f"Failed to get mtime of {self.query}", e)
+            raise WorkflowError(f"Failed to get mtime of {self.print_query}", e)
 
     async def managed_exists(self) -> bool:
         try:
             async with self._rate_limiter(Operation.EXISTS):
                 return self.exists()
         except Exception as e:
-            raise WorkflowError(f"Failed to check existence of {self.query}", e)
+            raise WorkflowError(f"Failed to check existence of {self.print_query}", e)
 
     async def managed_retrieve(self):
         try:
@@ -173,7 +174,7 @@ class StorageObjectRead(StorageObjectBase):
                 else:
                     os.remove(local_path)
             raise WorkflowError(
-                f"Failed to retrieve storage object from {self.query}", e
+                f"Failed to retrieve storage object from {self.print_query}", e
             )
 
 
@@ -189,14 +190,18 @@ class StorageObjectWrite(StorageObjectBase):
             async with self._rate_limiter(Operation.REMOVE):
                 self.remove()
         except Exception as e:
-            raise WorkflowError(f"Failed to remove storage object {self.query}", e)
+            raise WorkflowError(
+                f"Failed to remove storage object {self.print_query}", e
+            )
 
     async def managed_store(self):
         try:
             async with self._rate_limiter(Operation.STORE):
                 self.store_object()
         except Exception as e:
-            raise WorkflowError(f"Failed to store output in storage {self.query}", e)
+            raise WorkflowError(
+                f"Failed to store output in storage {self.print_query}", e
+            )
 
 
 class StorageObjectGlob(StorageObjectBase):
@@ -219,4 +224,4 @@ class StorageObjectTouch(StorageObjectBase):
             async with self._rate_limiter(Operation.TOUCH):
                 self.touch()
         except Exception as e:
-            raise WorkflowError(f"Failed to touch storage object {self.query}", e)
+            raise WorkflowError(f"Failed to touch storage object {self.print_query}", e)

--- a/snakemake_interface_storage_plugins/storage_provider.py
+++ b/snakemake_interface_storage_plugins/storage_provider.py
@@ -141,6 +141,14 @@ class StorageProviderBase(ABC):
         """
         return query
 
+    def safe_print(self, query: str) -> str:
+        """Process the query to remove potentially sensitive information when printing.
+
+        Useful if the query is URL-like and can contain authentication tokens in the
+        parameters and/or usernames/passwords.
+        """
+        return query
+
     @property
     def is_read_write(self) -> bool:
         from snakemake_interface_storage_plugins.storage_object import (


### PR DESCRIPTION
This adds an attribute to `storage_object` called `print_query` which allows a storage provider to change how a query is printed (e.g. removing senstitive information) through a new method `safe_print()` which by default just returns the query.

Related to issue https://github.com/snakemake/snakemake/issues/3087 and required for PR https://github.com/snakemake/snakemake/pull/3089.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a method to safely print query strings, designed to prevent accidental exposure of sensitive information.
- **Bug Fixes**
	- Improved error reporting by enhancing the clarity of exception messages related to storage operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->