### PR TITLE
fix: make ondemand eligibility determination smarter (respecting keep-local)

### DIFF
--- a/snakemake_interface_storage_plugins/storage_object.py
+++ b/snakemake_interface_storage_plugins/storage_object.py
@@ -81,7 +81,7 @@ class StorageObjectBase(ABC):
     @property
     def is_ondemand_eligible(self) -> bool:
         return self._is_ondemand_eligible and not self.keep_local
-    
+
     @is_ondemand_eligible.setter
     def is_ondemand_eligible(self, value: bool):
         self._is_ondemand_eligible = value

--- a/snakemake_interface_storage_plugins/storage_object.py
+++ b/snakemake_interface_storage_plugins/storage_object.py
@@ -66,17 +66,25 @@ class StorageObjectBase(ABC):
         retrieve: bool,
         provider: StorageProviderBase,
     ):
-        self.query = query
-        self.keep_local = keep_local
-        self.retrieve = retrieve
-        self.provider = provider
-        self.print_query = self.provider.safe_print(self.query)
-        self._overwrite_local_path = None
-        self.is_ondemand_eligible: bool = False
+        self.query: str = query
+        self.keep_local: bool = keep_local
+        self.retrieve: bool = retrieve
+        self.provider: StorageProviderBase = provider
+        self.print_query: str = self.provider.safe_print(self.query)
+        self._overwrite_local_path: Optional[Path] = None
+        self._is_ondemand_eligible: bool = False
         self.__post_init__()
 
     def __post_init__(self):  # noqa B027
         pass
+
+    @property
+    def is_ondemand_eligible(self) -> bool:
+        return self._is_ondemand_eligible and not self.keep_local
+    
+    @is_ondemand_eligible.setter
+    def is_ondemand_eligible(self, value: bool):
+        self._is_ondemand_eligible = value
 
     def set_local_path(self, path: Path) -> None:
         """Set a custom local path for this storage object."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated attribute handling to use explicit type annotations for improved clarity.
  - Transitioned an eligibility setting into a property with dedicated getter and setter, ensuring controlled access and modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->